### PR TITLE
chore: remove UPDATECLI_GITHUB_TOKEN env var, now integrated shared pipeline

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -6,9 +6,6 @@ pipeline {
     timeout(time: 10, unit: 'MINUTES')
     buildDiscarder(logRotator(numToKeepStr: '10'))
   }
-  environment{
-    UPDATECLI_GITHUB_TOKEN = credentials('updatecli-github-token')
-  }
   stages {
     stage('Updatecli DIFF') {
       steps {


### PR DESCRIPTION
Part of https://github.com/jenkins-infra/helpdesk/issues/2817