### PR TITLE
fix: keep the plan as binary to be able to use it for Infracost in the terraform shared pipeline

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -25,7 +25,8 @@ common-tests: $(TERRAFORM_PROJECT_DIR)/.terraform/plugins/selections.json ## Exe
 	@cd $(CURDIR)/tests/ && go mod download && go test -v -timeout 30m
 
 plan: lint $(TERRAFORM_PROJECT_DIR)/.terraform/plugins/selections.json ## Write the planned changes into $(PLAN_FILE_NAME) (but do NOT apply them)
-	@cd $(TERRAFORM_PROJECT_DIR) && terraform plan -compact-warnings -lock=false -no-color > $(TERRAFORM_PROJECT_DIR)/$(PLAN_FILE_NAME)
+	@cd $(TERRAFORM_PROJECT_DIR) && terraform plan -compact-warnings -lock=false -out=tfplan > /dev/null 2>&1
+	@cd $(TERRAFORM_PROJECT_DIR) && terraform show -no-color tfplan > $(TERRAFORM_PROJECT_DIR)/$(PLAN_FILE_NAME)
 	@echo "Terraform plan output can be checked under the file ./$(PLAN_FILE_NAME)"
 
 deploy: lint $(TERRAFORM_PROJECT_DIR)/.terraform/plugins/selections.json ## Deploy (apply) the terraform changes to production


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2852