### PR TITLE
chore(terratest): fix name displayed in logs

### DIFF
--- a/terraform/tests/terraform_main_test.go
+++ b/terraform/tests/terraform_main_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
-func TestTerraformEksCluster(t *testing.T) {
+func TestTerraformCluster(t *testing.T) {
 
 	// Construct the terraform options with default retryable errors to handle the most common
 	// retryable errors in terraform testing.


### PR DESCRIPTION
This shared test isn't used only on EKS clusters.

<img width="554" alt="image" src="https://github.com/jenkins-infra/shared-tools/assets/91831478/e56e0825-f7d5-49ce-a3ea-5e43c60fa2b6">
