### PR TITLE
Remove IPv6 incompatible with Azure API server authorized IP range

### DIFF
--- a/terraform/modules/jenkins-infra-shared-data/outputs.tf
+++ b/terraform/modules/jenkins-infra-shared-data/outputs.tf
@@ -1,7 +1,7 @@
 output "admin_public_ips" {
   value = {
     dduportal       = ["109.88.234.158"],
-    lemeurherve     = ["176.185.227.180", "2a01:e0a:b69:da30:5d59:cfbe:b675:e66d"],
+    lemeurherve     = ["176.185.227.180"],
     smerle33        = ["82.64.5.129"],
     mwaite          = ["162.142.59.220"],
   }

--- a/terraform/modules/jenkins-infra-shared-data/outputs.tf
+++ b/terraform/modules/jenkins-infra-shared-data/outputs.tf
@@ -1,8 +1,7 @@
 output "admin_public_ips" {
   value = {
     dduportal       = ["109.88.234.158"],
-    lemeurherve     = ["176.185.227.180"],
-    lemeurherve_ext = ["2a01:e0a:b69:da30:5d59:cfbe:b675:e66d"],
+    lemeurherve     = ["176.185.227.180", "2a01:e0a:b69:da30:5d59:cfbe:b675:e66d"],
     smerle33        = ["82.64.5.129"],
     mwaite          = ["162.142.59.220"],
   }


### PR DESCRIPTION
Error from https://infra.ci.jenkins.io/job/terraform-jobs/job/azure/job/main/815/pipeline-console/?selected-node=49

```
Error: api_server_access_profile.0.authorized_ip_ranges.6 must start with IPV4 address and/or slash, number of bits (0-32) as prefix. Example: 127.0.0.1/8. Got "2a01:e0a:b69:da30:5d59:cfbe:b675:e66d/32".

on [publick8s.tf](http://publick8s.tf/) line 35, in resource "azurerm_kubernetes_cluster" "publick8s":
   authorized_ip_ranges = setunion(
```

Nothing about that constraint in the provider: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster

Azure doc related to API server authorized IP range: https://learn.microsoft.com/en-us/azure/aks/api-server-authorized-ip-ranges