### PR TITLE
chore(fileshare-serviceprincipal-writer): add sensitive `password` output

### DIFF
--- a/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer/outputs.tf
+++ b/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer/outputs.tf
@@ -5,3 +5,8 @@ output "service_fqdn" {
 output "fileshare_serviceprincipal_writer_id" {
   value = azuread_service_principal.fileshare_serviceprincipal_writer.id
 }
+
+output "fileshare_serviceprincipal_writer_password" {
+  sensitive = true
+  value = azuread_application_password.fileshare_serviceprincipal_writer.value
+}


### PR DESCRIPTION
This PR adds a sensitive `password` output as its value can't be retrieved from the Azure Portal.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414