### PR TITLE
fix(fileshare): return application `client_id` instead of service principal id

### DIFF
--- a/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer/outputs.tf
+++ b/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer/outputs.tf
@@ -3,7 +3,7 @@ output "service_fqdn" {
 }
 
 output "fileshare_serviceprincipal_writer_id" {
-  value = azuread_service_principal.fileshare_serviceprincipal_writer.id
+  value = azuread_application.fileshare_serviceprincipal_writer.client_id
 }
 
 output "fileshare_serviceprincipal_writer_password" {


### PR DESCRIPTION
This PR fixes the fileshare output by selecting the service principal application `client_id` and not the service principal id.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414#issuecomment-1896199534
- https://learn.microsoft.com/en-us/cli/azure/authenticate-azure-cli-service-principal
