### PR TITLE
feat(terraform: `azure-jenkinsinfra-controller`) allow DNS to use distinct provider or to be undefined

### DIFF
--- a/terraform/modules/azure-jenkinsinfra-controller/main.tf
+++ b/terraform/modules/azure-jenkinsinfra-controller/main.tf
@@ -39,7 +39,7 @@ resource "azurerm_management_lock" "controller_publicip" {
   notes      = "Locked because this is a sensitive resource that should not be removed"
 }
 resource "azurerm_dns_a_record" "controller" {
-  count               = var.is_public ? 1 : 0
+  count               = var.is_public && var.dns_zone_name != "" ? 1 : 0
   name                = trimsuffix(trimsuffix(local.controller_fqdn, var.dns_zone), ".")
   zone_name           = var.dns_zone_name
   resource_group_name = var.dns_resourcegroup_name
@@ -48,7 +48,7 @@ resource "azurerm_dns_a_record" "controller" {
   tags                = var.default_tags
 }
 resource "azurerm_dns_a_record" "private_controller" {
-  count               = var.is_public ? 1 : 0
+  count               = var.is_public && var.dns_zone_name != "" ? 1 : 0
   name                = "private.${azurerm_dns_a_record.controller[0].name}"
   zone_name           = var.dns_zone_name
   resource_group_name = var.dns_resourcegroup_name

--- a/terraform/modules/azure-jenkinsinfra-controller/main.tf
+++ b/terraform/modules/azure-jenkinsinfra-controller/main.tf
@@ -40,6 +40,7 @@ resource "azurerm_management_lock" "controller_publicip" {
 }
 resource "azurerm_dns_a_record" "controller" {
   count               = var.is_public && var.dns_zone_name != "" ? 1 : 0
+  provider            = azurerm.dns
   name                = trimsuffix(trimsuffix(local.controller_fqdn, var.dns_zone), ".")
   zone_name           = var.dns_zone_name
   resource_group_name = var.dns_resourcegroup_name
@@ -49,6 +50,7 @@ resource "azurerm_dns_a_record" "controller" {
 }
 resource "azurerm_dns_a_record" "private_controller" {
   count               = var.is_public && var.dns_zone_name != "" ? 1 : 0
+  provider            = azurerm.dns
   name                = "private.${azurerm_dns_a_record.controller[0].name}"
   zone_name           = var.dns_zone_name
   resource_group_name = var.dns_resourcegroup_name

--- a/terraform/modules/azure-jenkinsinfra-controller/providers.tf
+++ b/terraform/modules/azure-jenkinsinfra-controller/providers.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
+      source                = "hashicorp/azurerm"
+      configuration_aliases = [azurerm.dns]
     }
     azuread = {
       source = "hashicorp/azuread"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3913 (edited).

Migrating the controller VM to the new subscription will need instantiating the module `azure-jenkinsinfra-controller` (either a new one or the current one). This module takes care of creating not only the VM, but also DNS records to reach this VM. But as our DNS zones for the `jenkins.io` and `jenkins-ci.org` domains are NOT in the secondary (sponsored) subscription, it will be an obstacle.

As a remidation, this PR adds a new feature to the terraform module `azure-jenkinsinfra-controller` to allow DNS records:

- To be managed by a distinct AzureRM provider
- To NOT be managed

So we can handle many cases during the migration of ci.jenkins.io

Tested with success:

- Using a local `terraform plan` against the 3 existing controllers:

```shell
$ terraform plan --target=module.ci_jenkins_io -target=module.trusted_ci_jenkins_io -target=module.cert_ci_jenkins_io
# ...

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your
configuration and found no differences, so no changes are needed.
╷
│ Warning: Resource targeting is in effect
# ...
```

- Using the local copy of https://github.com/jenkins-infra/azure/pull/583 (edited):

```shell
$ terraform plan --target=module.ci_jenkins_io -target=module.trusted_ci_jenkins_io -target=module.cert_ci_jenkins_io --target=module.ci_jenkins_io_sponsorship

# ...
Plan: 25 to add, 0 to change, 0 to destroy.
╷
│ Warning: Resource targeting is in effect
```