### PR TITLE
Revert "fix(fileshare): return application `client_id` instead of service principal id"

### DIFF
--- a/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer/outputs.tf
+++ b/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer/outputs.tf
@@ -3,7 +3,7 @@ output "service_fqdn" {
 }
 
 output "fileshare_serviceprincipal_writer_id" {
-  value = azuread_application.fileshare_serviceprincipal_writer.client_id
+  value = azuread_service_principal.fileshare_serviceprincipal_writer.id
 }
 
 output "fileshare_serviceprincipal_writer_password" {


### PR DESCRIPTION
Reverts jenkins-infra/shared-tools#134

Using the service principal id instead of the Azure Application client_id.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414