### PR TITLE
feat(fileshare-writer): add Storage Account role assignment

### DIFF
--- a/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer/main.tf
+++ b/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer/main.tf
@@ -34,7 +34,14 @@ resource "azuread_service_principal_password" "fileshare_serviceprincipal_writer
 
 # https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-authorize-azure-active-directory#verify-role-assignments
 resource "azurerm_role_assignment" "file_share_privileged_contributor" {
-  scope                = var.file_share_id
+  scope                = var.file_share_resource_manager_id
   role_definition_name = "Storage File Data Privileged Contributor"
+  principal_id         = azuread_service_principal.fileshare_serviceprincipal_writer.id
+}
+
+# Needed so the service principal can access the Storage Account access key to generate a SAS token
+resource "azurerm_role_assignment" "storage_account_privileged_contributor" {
+  scope                = var.storage_account_id
+  role_definition_name = "Storage Account Contributor"
   principal_id         = azuread_service_principal.fileshare_serviceprincipal_writer.id
 }

--- a/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer/variables.tf
+++ b/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer/variables.tf
@@ -15,7 +15,11 @@ variable "service_principal_end_date" {
   type = string
 }
 
-variable "file_share_id" {
+variable "file_share_resource_manager_id" {
+  type = string
+}
+
+variable "storage_account_id" {
   type = string
 }
 


### PR DESCRIPTION
This PR adds the Storage Account role assignment to the fileshare-writer service principal, needed so it can access the Storage Account access key to generate a SAS token.

It also rename the module input variable `file_share_id` to `file_share_resource_manager_id` to avoid confusion.

Tested locally.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414#issuecomment-1942141701