### PR TITLE
feat(terraform-modules/azure-nat-gateway) introduces support for additional outbound IPs

### DIFF
--- a/terraform/modules/azure-nat-gateway/main.tf
+++ b/terraform/modules/azure-nat-gateway/main.tf
@@ -23,7 +23,7 @@ resource "azurerm_public_ip" "outbound" {
   sku                 = "Standard"
 }
 resource "azurerm_public_ip" "additional_outbounds" {
-  count               = var.amount_outbound_ips - 1 # Substract 1: the principal outbound IP
+  count               = var.outbound_ip_count - 1 # Substract 1: the principal outbound IP
   name                = format("%s-additional-%d", var.name, count.index)
   location            = data.azurerm_resource_group.outbound.location
   resource_group_name = data.azurerm_resource_group.outbound.name

--- a/terraform/modules/azure-nat-gateway/main.tf
+++ b/terraform/modules/azure-nat-gateway/main.tf
@@ -22,6 +22,14 @@ resource "azurerm_public_ip" "outbound" {
   allocation_method   = "Static"
   sku                 = "Standard"
 }
+resource "azurerm_public_ip" "additional_outbounds" {
+  count               = var.amount_outbound_ips - 1 # Substract 1: the principal outbound IP
+  name                = format("%s-additional-%d", var.name, count.index)
+  location            = data.azurerm_resource_group.outbound.location
+  resource_group_name = data.azurerm_resource_group.outbound.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
 resource "azurerm_nat_gateway" "outbound" {
   name                = var.name
   location            = data.azurerm_resource_group.outbound.location

--- a/terraform/modules/azure-nat-gateway/outputs.tf
+++ b/terraform/modules/azure-nat-gateway/outputs.tf
@@ -1,3 +1,3 @@
 output "public_ip" {
-  value = var.amount_outbound_ips == 1 ? azurerm_public_ip.outbound.ip_address : join(",", concat([azurerm_public_ip.outbound.ip_address], azurerm_public_ip.additional_outbounds.*.ip_address))
+  value = var.outbound_ip_count == 1 ? azurerm_public_ip.outbound.ip_address : join(",", concat([azurerm_public_ip.outbound.ip_address], azurerm_public_ip.additional_outbounds.*.ip_address))
 }

--- a/terraform/modules/azure-nat-gateway/outputs.tf
+++ b/terraform/modules/azure-nat-gateway/outputs.tf
@@ -1,3 +1,3 @@
-output "public_ip" {
+output "public_ip_list" {
   value = var.outbound_ip_count == 1 ? azurerm_public_ip.outbound.ip_address : join(",", concat([azurerm_public_ip.outbound.ip_address], azurerm_public_ip.additional_outbounds.*.ip_address))
 }

--- a/terraform/modules/azure-nat-gateway/outputs.tf
+++ b/terraform/modules/azure-nat-gateway/outputs.tf
@@ -1,3 +1,3 @@
 output "public_ip" {
-  value = azurerm_public_ip.outbound
+  value = var.amount_outbound_ips == 1 ? azurerm_public_ip.outbound.ip_address : join(",", concat([azurerm_public_ip.outbound.ip_address], azurerm_public_ip.additional_outbounds.*.ip_address))
 }

--- a/terraform/modules/azure-nat-gateway/variables.tf
+++ b/terraform/modules/azure-nat-gateway/variables.tf
@@ -20,6 +20,6 @@ variable "subnet_names" {
 
 variable "outbound_ip_count" {
   type        = number
-  description = "Amount of additional outbound Ips to use."
+  description = "Number of outbound IPs to use."
   default     = 1
 }

--- a/terraform/modules/azure-nat-gateway/variables.tf
+++ b/terraform/modules/azure-nat-gateway/variables.tf
@@ -17,3 +17,9 @@ variable "subnet_names" {
   type        = list(string)
   description = "List of subnets (names) to associate with this gateway"
 }
+
+variable "amount_outbound_ips" {
+  type        = number
+  description = "Amount of additional outbound Ips to use."
+  default     = 1
+}

--- a/terraform/modules/azure-nat-gateway/variables.tf
+++ b/terraform/modules/azure-nat-gateway/variables.tf
@@ -18,7 +18,7 @@ variable "subnet_names" {
   description = "List of subnets (names) to associate with this gateway"
 }
 
-variable "amount_outbound_ips" {
+variable "outbound_ip_count" {
   type        = number
   description = "Amount of additional outbound Ips to use."
   default     = 1


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4029

This change adds the ability to increase the amount of outbound IPs. (see https://github.com/jenkins-infra/azure-net/pull/221 for instance).

Note that the additional IPs are specified as a distinct resource set than the current `azurerm_public_ip.outbound`:

- The "multiple outbound IPs" is an edge case only for trusted.ci agents (at least for now)
- The idea is to avoid having to move resources inside terraform state to go quickly.

=> It is only an implementation detail: the input variables and module outputs are mixing the "principal" outbound IP and the eventual addition all together so consumers don't have to care.

=> If the reality catch us and makes the "multiple outbound IPs" the nominal case, then we'll consider implementing a single set of `azurerm_public_ip` and migrate existing resources once for all.


----


Tests done to ensure this change is valid:

- Tested the current `main` branch of jenkins-infra/azure-net with this version (https://github.com/jenkins-infra/azure-net/blob/main/gateways.tf#L42-L55). Result was:

```
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```

- Tested https://github.com/jenkins-infra/azure-net/pull/221 with the current change and the result was:

```
Terraform will perform the following actions:

  # module.trusted_outbound_sponsorship.azurerm_public_ip.additional_outbounds[0] will be created
  + resource "azurerm_public_ip" "additional_outbounds" {
      + allocation_method       = "Static"
      + ddos_protection_mode    = "VirtualNetworkInherited"
      + fqdn                    = (known after apply)
      + id                      = (known after apply)
      + idle_timeout_in_minutes = 4
      + ip_address              = (known after apply)
      + ip_version              = "IPv4"
      + location                = "eastus2"
      + name                    = "trusted-outbound-sponsorship-additional-0"
      + resource_group_name     = "trusted-ci-jenkins-io-sponsorship"
      + sku                     = "Standard"
      + sku_tier                = "Regional"
    }

  # module.trusted_outbound_sponsorship.azurerm_public_ip.additional_outbounds[1] will be created
  + resource "azurerm_public_ip" "additional_outbounds" {
      + allocation_method       = "Static"
      + ddos_protection_mode    = "VirtualNetworkInherited"
      + fqdn                    = (known after apply)
      + id                      = (known after apply)
      + idle_timeout_in_minutes = 4
      + ip_address              = (known after apply)
      + ip_version              = "IPv4"
      + location                = "eastus2"
      + name                    = "trusted-outbound-sponsorship-additional-1"
      + resource_group_name     = "trusted-ci-jenkins-io-sponsorship"
      + sku                     = "Standard"
      + sku_tier                = "Regional"
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```