### PR TITLE
chore(adoptium): rename scripts and apply shellcheck

### DIFF
--- a/adoptium/adoptium-get-jdk-link.sh
+++ b/adoptium/adoptium-get-jdk-link.sh
@@ -5,42 +5,42 @@
 # If two arguments were passed, assign them to JAVA_VERSION and OS respectively
 # If three arguments were passed, assign them to JAVA_VERSION, OS and ARCHS respectively
 # If not, check if JAVA_VERSION and OS are already set. If they're not set, exit the script with an error message
-if [ $# -eq 1 ] && [ -n "$JAVA_VERSION" ]; then
-    OS=$1
+if [ $# -eq 1 ] && [ -n "${JAVA_VERSION}" ]; then
+    OS="${1}"
 elif [ $# -eq 2 ]; then
-    JAVA_VERSION=$1
-    OS=$2
+    JAVA_VERSION="${1}"
+    OS="${2}"
 elif [ $# -eq 3 ]; then
-    JAVA_VERSION=$1
-    OS=$2
+    JAVA_VERSION="${1}"
+    OS="${2}"
     ARCHS=$3
-elif [ -z "$JAVA_VERSION" ] && [ -z "$OS" ]; then
+elif [ -z "${JAVA_VERSION}" ] && [ -z "${OS}" ]; then
     echo "Error: No Java version and OS specified. Please set the JAVA_VERSION and OS environment variables or pass them as arguments." >&2
     exit 1
-elif [ -z "$JAVA_VERSION" ]; then
+elif [ -z "${JAVA_VERSION}" ]; then
     echo "Error: No Java version specified. Please set the JAVA_VERSION environment variable or pass it as an argument." >&2
     exit 1
-elif [ -z "$OS" ]; then
-    OS=$1
-    if [ -z "$OS" ]; then
+elif [ -z "${OS}" ]; then
+    OS="${1}"
+    if [ -z "${OS}" ]; then
         echo "Error: No OS specified. Please set the OS environment variable or pass it as an argument." >&2
         exit 1
     fi
 fi
 
 # Check if ARCHS is set. If it's not set, assign the current architecture to it
-if [ -z "$ARCHS" ]; then
+if [ -z "${ARCHS}" ]; then
     ARCHS=$(uname -m | sed -e 's/x86_64/x64/' -e 's/armv7l/arm/')
 else
     # Convert ARCHS to an array
-    OLD_IFS=$IFS
+    OLD_IFS="${IFS}"
     IFS=','
-    set -- "$ARCHS"
+    set -- "${ARCHS}"
     ARCHS=""
     for arch in "$@"; do
-        ARCHS="$ARCHS $arch"
+        ARCHS="${ARCHS} ${arch}"
     done
-    IFS=$OLD_IFS
+    IFS="${OLD_IFS}"
 fi
 
 # Check if jq and curl are installed
@@ -51,17 +51,17 @@ if ! command -v jq >/dev/null 2>&1 || ! command -v curl >/dev/null 2>&1; then
 fi
 
 # Replace underscores with plus signs in JAVA_VERSION
-ARCHIVE_DIRECTORY=$(echo "$JAVA_VERSION" | tr '_' '+')
+ARCHIVE_DIRECTORY=$(echo "${JAVA_VERSION}" | tr '_' '+')
 
 # URL encode ARCHIVE_DIRECTORY
-ENCODED_ARCHIVE_DIRECTORY=$(echo "$ARCHIVE_DIRECTORY" | xargs -I {} printf %s {} | jq "@uri" -jRr)
+ENCODED_ARCHIVE_DIRECTORY=$(echo "${ARCHIVE_DIRECTORY}" | xargs -I {} printf %s {} | jq "@uri" -jRr)
 
 # Determine the OS type for the URL
 OS_TYPE="linux"
-if [ "$OS" = "alpine" ]; then
+if [ "${OS}" = "alpine" ]; then
     OS_TYPE="alpine-linux"
 fi
-if [ "$OS" = "windows" ]; then
+if [ "${OS}" = "windows" ]; then
     OS_TYPE="windows"
 fi
 
@@ -69,38 +69,38 @@ fi
 FIRST_ARCH_URL=""
 
 # Loop over the array of architectures
-for ARCH in $ARCHS; do
+for ARCH in ${ARCHS}; do
     # Fetch the download URL from the Adoptium API
     URL="https://api.adoptium.net/v3/binary/version/jdk-${ENCODED_ARCHIVE_DIRECTORY}/${OS_TYPE}/${ARCH}/jdk/hotspot/normal/eclipse?project=jdk"
 
-    if ! RESPONSE=$(curl -fsI "$URL"); then
+    if ! RESPONSE=$(curl -fsI "${URL}"); then
         echo "Error: Failed to fetch the URL for architecture ${ARCH}. Exiting with status 1." >&2
-        echo "Response: $RESPONSE" >&2
+        echo "Response: ${RESPONSE}" >&2
         exit 1
     fi
 
     # Extract the redirect URL from the HTTP response
-    REDIRECTED_URL=$(echo "$RESPONSE" | grep Location | awk '{print $2}' | tr -d '\r')
+    REDIRECTED_URL=$(echo "${RESPONSE}" | grep Location | awk '{print $2}' | tr -d '\r')
 
     # If no redirect URL was found, exit the script with an error message
-    if [ -z "$REDIRECTED_URL" ]; then
+    if [ -z "${REDIRECTED_URL}" ]; then
         echo "Error: No redirect URL found for architecture ${ARCH}. Exiting with status 1." >&2
-        echo "Response: $RESPONSE" >&2
+        echo "Response: ${RESPONSE}" >&2
         exit 1
     fi
 
     # Use curl to check if the URL is reachable
     # If the URL is not reachable, print an error message and exit the script with status 1
-    if ! curl -v -fs "$REDIRECTED_URL" >/dev/null 2>&1; then
+    if ! curl -v -fs "${REDIRECTED_URL}" >/dev/null 2>&1; then
         echo "${REDIRECTED_URL}" is not reachable for architecture "${ARCH}". >&2
         exit 1
     fi
 
     # If FIRST_ARCH_URL is empty, store the current URL
-    if [ -z "$FIRST_ARCH_URL" ]; then
-        FIRST_ARCH_URL=$REDIRECTED_URL
+    if [ -z "${FIRST_ARCH_URL}" ]; then
+        FIRST_ARCH_URL=${REDIRECTED_URL}
     fi
 done
 
 # If all downloads are successful, print the URL for the first architecture
-echo "$FIRST_ARCH_URL"
+echo "${FIRST_ARCH_URL}"

--- a/adoptium/adoptium-install-jdk.sh
+++ b/adoptium/adoptium-install-jdk.sh
@@ -1,24 +1,28 @@
 #!/bin/sh
 set -x
+
 # Check if curl and tar are installed
 if ! command -v curl >/dev/null 2>&1 || ! command -v tar >/dev/null 2>&1 ; then
     echo "curl and tar are required but not installed. Exiting with status 1." >&2
     exit 1
 fi
 
+# Check required variable
+: "${JAVA_VERSION:?}"
+
 # Set the OS to "standard" by default
 OS="standard"
 
 # If a second argument is provided, use it as the OS
 if [ $# -eq 1 ]; then
-    OS=$1
+    OS="${1}"
 fi
 
-# Call jdk-download-url.sh with JAVA_VERSION and OS as arguments
+# Call adoptium-get-jdk-link.sh with JAVA_VERSION and OS as arguments
 # The two scripts should be in the same directory.
 # That's why we're trying to find the directory of the current script and use it to call the other script.
 SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd)
-if ! DOWNLOAD_URL=$("${SCRIPT_DIR}"/jdk-download-url.sh "${JAVA_VERSION}" "${OS}"); then
+if ! DOWNLOAD_URL=$("${SCRIPT_DIR}"/adoptium-get-jdk-link.sh "${JAVA_VERSION}" "${OS}"); then
     echo "Error: Failed to fetch the URL. Exiting with status 1." >&2
     exit 1
 fi


### PR DESCRIPTION
This PR renames Adoptium scripts and apply shellcheck recommendations to them, keeping changes to their minimum before adding updatecli manifests (and updating by the same occasion the names of these scripts) in consumer repositories.

Future improvements of these scripts could then be automatically proposed to consumers.

Tested by building all linux images locally with these scripts in the 3 existing consumer repos.