### PR TITLE
chore: add new `fileshare_serviceprincipal_writer_application_client_password`

### DIFF
--- a/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer/outputs.tf
+++ b/terraform/modules/azure-jenkinsinfra-fileshare-serviceprincipal-writer/outputs.tf
@@ -2,10 +2,12 @@ output "service_fqdn" {
   value = var.service_fqdn
 }
 
+# TODO: to be removed, see https://github.com/jenkins-infra/helpdesk/issues/4149
 output "fileshare_serviceprincipal_writer_id" {
   value = azuread_service_principal.fileshare_serviceprincipal_writer.id
 }
 
+# TODO: to be removed & replaced by fileshare_serviceprincipal_writer_application_client_password, see https://github.com/jenkins-infra/helpdesk/issues/4149
 output "fileshare_serviceprincipal_writer_password" {
   sensitive = true
   value     = azuread_application_password.fileshare_serviceprincipal_writer.value
@@ -15,10 +17,17 @@ output "fileshare_serviceprincipal_writer_application_client_id" {
   value = azuread_application.fileshare_serviceprincipal_writer.client_id
 }
 
+output "fileshare_serviceprincipal_writer_application_client_password" {
+  sensitive = true
+  value     = azuread_application_password.fileshare_serviceprincipal_writer.value
+}
+
+# TODO: to be removed, see https://github.com/jenkins-infra/helpdesk/issues/4149
 output "fileshare_serviceprincipal_writer_sp_id" {
   value = azuread_service_principal.fileshare_serviceprincipal_writer.id
 }
 
+# TODO: to be removed, see https://github.com/jenkins-infra/helpdesk/issues/4149
 output "fileshare_serviceprincipal_writer_sp_password" {
   sensitive = true
   value     = azuread_service_principal_password.fileshare_serviceprincipal_writer.value


### PR DESCRIPTION
This PR adds `fileshare_serviceprincipal_writer_application_client_password` new output with the same value as the existing `fileshare_serviceprincipal_writer_password` output, to get a more descriptive output name removing the ambiguity about if it's the password of a service principal or an application client.

It also add TODO comments to remove service principal id and password outputs, which will be done at a last step (see plan at https://github.com/jenkins-infra/helpdesk/issues/4149).

I added this one instead of renaming the existing one so it doesn't break existing consumers.

Next steps concerning this change:
- Use this new output in jenkins-infra/azure
- Remove the old output

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4149