### PR TITLE
fix(terraform/azure-nat-gateway) decouple NAT gateways from subnets to allow one-shot creation

### DIFF
--- a/terraform/modules/azure-nat-gateway/main.tf
+++ b/terraform/modules/azure-nat-gateway/main.tf
@@ -4,17 +4,6 @@
 data "azurerm_resource_group" "outbound" {
   name = var.resource_group_name
 }
-data "azurerm_virtual_network" "outbound" {
-  name                = var.vnet_name
-  resource_group_name = var.resource_group_name
-}
-data "azurerm_subnet" "outbound" {
-  for_each = toset(var.subnet_names)
-
-  name                 = each.key
-  virtual_network_name = var.vnet_name
-  resource_group_name  = var.resource_group_name
-}
 resource "azurerm_public_ip" "outbound" {
   name                = var.name
   location            = data.azurerm_resource_group.outbound.location
@@ -46,7 +35,7 @@ resource "azurerm_nat_gateway_public_ip_association" "outbound" {
   public_ip_address_id = azurerm_public_ip.outbound.id
 }
 resource "azurerm_subnet_nat_gateway_association" "outbound" {
-  for_each       = toset(var.subnet_names)
-  subnet_id      = data.azurerm_subnet.outbound[each.key].id
+  count          = length(var.subnet_ids)
+  subnet_id      = var.subnet_ids[count.index]
   nat_gateway_id = azurerm_nat_gateway.outbound.id
 }

--- a/terraform/modules/azure-nat-gateway/variables.tf
+++ b/terraform/modules/azure-nat-gateway/variables.tf
@@ -13,9 +13,9 @@ variable "vnet_name" {
   description = "Name of the Virtual Network to use"
 }
 
-variable "subnet_names" {
+variable "subnet_ids" {
   type        = list(string)
-  description = "List of subnets (names) to associate with this gateway"
+  description = "List of subnets IDs to associate with this gateway"
 }
 
 variable "outbound_ip_count" {


### PR DESCRIPTION
To avoid PRs such as https://github.com/jenkins-infra/azure-net/pull/231, we want to allow creation of a given subnet in the same change as the NAT gateway association.

This PR allows to decouple both by removing the data source intermediate. Instead, the subnet IDs are passed as inputs to the module, creating an explicit dependency: the module resources (nat gatewats, etc.) won't be created until the subnet ID is available.

