### PR TITLE
chore(temurin Adoptium install scripts) provide visibility for curl and retry downloads

### DIFF
--- a/adoptium/adoptium-get-jdk-link.sh
+++ b/adoptium/adoptium-get-jdk-link.sh
@@ -73,7 +73,7 @@ for ARCH in ${ARCHS}; do
     # Fetch the download URL from the Adoptium API
     URL="https://api.adoptium.net/v3/binary/version/jdk-${ENCODED_ARCHIVE_DIRECTORY}/${OS_TYPE}/${ARCH}/jdk/hotspot/normal/eclipse?project=jdk"
 
-    if ! RESPONSE=$(curl -fsI "${URL}"); then
+    if ! RESPONSE=$(curl --fail --silent --show-error --retry 5 --retry-connrefused --head "${URL}"); then
         echo "Error: Failed to fetch the URL for architecture ${ARCH}. Exiting with status 1." >&2
         echo "Response: ${RESPONSE}" >&2
         exit 1
@@ -91,7 +91,7 @@ for ARCH in ${ARCHS}; do
 
     # Use curl to check if the URL is reachable
     # If the URL is not reachable, print an error message and exit the script with status 1
-    if ! curl -v -fs "${REDIRECTED_URL}" >/dev/null 2>&1; then
+    if ! curl --fail --silent --show-error --retry 5 --retry-connrefused "${REDIRECTED_URL}" >/dev/null 2>&1; then
         echo "${REDIRECTED_URL}" is not reachable for architecture "${ARCH}". >&2
         exit 1
     fi

--- a/adoptium/adoptium-install-jdk.sh
+++ b/adoptium/adoptium-install-jdk.sh
@@ -28,7 +28,7 @@ if ! DOWNLOAD_URL=$("${SCRIPT_DIR}"/adoptium-get-jdk-link.sh "${JAVA_VERSION}" "
 fi
 
 # Use curl to download the JDK archive from the URL
-if ! curl --silent --location --output /tmp/jdk.tar.gz "${DOWNLOAD_URL}"; then
+if ! curl --silent --show-error --location --retry 5 --retry-connrefused --output /tmp/jdk.tar.gz "${DOWNLOAD_URL}"; then
     echo "Error: Failed to download the JDK archive. Exiting with status 1." >&2
     exit 1
 fi


### PR DESCRIPTION
This PR upstreams the change https://github.com/jenkinsci/docker-agent/pull/868.

The PRs https://github.com/jenkinsci/docker-agent/pull/870 and https://github.com/jenkinsci/docker-agent/pull/869 were automatically opened after https://github.com/jenkinsci/docker-agent/pull/868. as I forgot we had this automation tool.
