### PR TITLE
fix: Adapt to recent changes in JDK download URL response

### DIFF
--- a/adoptium/adoptium-get-jdk-link.sh
+++ b/adoptium/adoptium-get-jdk-link.sh
@@ -74,17 +74,17 @@ for ARCH in ${ARCHS}; do
     URL="https://api.adoptium.net/v3/binary/version/jdk-${ENCODED_ARCHIVE_DIRECTORY}/${OS_TYPE}/${ARCH}/jdk/hotspot/normal/eclipse?project=jdk"
 
     if ! RESPONSE=$(curl --fail --silent --show-error --retry 5 --retry-connrefused --head "${URL}"); then
-        echo "Error: Failed to fetch the URL for architecture ${ARCH}. Exiting with status 1." >&2
+        echo "Error: Failed to fetch the URL for architecture ${ARCH} for ${URL}. Exiting with status 1." >&2
         echo "Response: ${RESPONSE}" >&2
         exit 1
     fi
 
     # Extract the redirect URL from the HTTP response
-    REDIRECTED_URL=$(echo "${RESPONSE}" | grep Location | awk '{print $2}' | tr -d '\r')
+    REDIRECTED_URL=$(echo "${RESPONSE}" | grep -i location | awk '{print $2}' | tr -d '\r')
 
     # If no redirect URL was found, exit the script with an error message
     if [ -z "${REDIRECTED_URL}" ]; then
-        echo "Error: No redirect URL found for architecture ${ARCH}. Exiting with status 1." >&2
+        echo "Error: No redirect URL found for architecture ${ARCH} for ${URL}. Exiting with status 1." >&2
         echo "Response: ${RESPONSE}" >&2
         exit 1
     fi


### PR DESCRIPTION
## fix: Adapt to recent changes in JDK download URL response

https://github.com/jenkinsci/docker/pull/1936 discovered that the response parsing in our download script was assuming `Location:` in the header and Adoptium changed to replying with `location:`.

This change is needed in shared tools to prevent pull requests like:

* https://github.com/jenkinsci/docker-agent/pull/893
* https://github.com/jenkinsci/docker-agent/pull/895
