### PR TITLE
chore(jenkins-infra-azure-vm-agents) filters out ipv6 ips for github `git` end points

### DIFF
--- a/terraform/modules/azure-jenkinsinfra-azurevm-agents/main.tf
+++ b/terraform/modules/azure-jenkinsinfra-azurevm-agents/main.tf
@@ -78,6 +78,7 @@ resource "azurerm_network_security_rule" "allow_outbound_ssh_from_ephemeral_agen
   source_port_range           = "*"
   source_address_prefixes     = data.azurerm_subnet.ephemeral_agents.address_prefixes
   destination_port_range      = "22"
+  #Filter only for ipv4 ips
   destination_address_prefixes = [
     for ip in split(" ", local.github_destination_address_prefixes) : ip
     if can(cidrnetmask("${ip}/32"))

--- a/terraform/modules/azure-jenkinsinfra-azurevm-agents/main.tf
+++ b/terraform/modules/azure-jenkinsinfra-azurevm-agents/main.tf
@@ -81,7 +81,7 @@ resource "azurerm_network_security_rule" "allow_outbound_ssh_from_ephemeral_agen
   #Filter only for ipv4 ips
   destination_address_prefixes = [
     for ip in split(" ", local.github_destination_address_prefixes) : ip
-    if can(cidrnetmask("${ip}/32"))
+    if can(cidrnetmask(ip))
   ]
   resource_group_name         = var.controller_rg_name
   network_security_group_name = azurerm_network_security_group.ephemeral_agents.name

--- a/terraform/modules/azure-jenkinsinfra-azurevm-agents/main.tf
+++ b/terraform/modules/azure-jenkinsinfra-azurevm-agents/main.tf
@@ -78,7 +78,10 @@ resource "azurerm_network_security_rule" "allow_outbound_ssh_from_ephemeral_agen
   source_port_range           = "*"
   source_address_prefixes     = data.azurerm_subnet.ephemeral_agents.address_prefixes
   destination_port_range      = "22"
-  destination_address_prefixes = split(" ", local.github_destination_address_prefixes)
+  destination_address_prefixes = [
+    for ip in split(" ", local.github_destination_address_prefixes) : ip
+    if can(cidrnetmask("${ip}/32"))
+  ]
   resource_group_name         = var.controller_rg_name
   network_security_group_name = azurerm_network_security_group.ephemeral_agents.name
 }


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4398#issuecomment-2511688286

This PR filters out ipv6 ips for github `git` end points since we only want ipv4 ips