### PR TITLE
Revert "fix(azure VM agents): revert to outgoing port 22 to internet for packer-images build"

### DIFF
--- a/terraform/modules/azure-jenkinsinfra-azurevm-agents/main.tf
+++ b/terraform/modules/azure-jenkinsinfra-azurevm-agents/main.tf
@@ -78,12 +78,11 @@ resource "azurerm_network_security_rule" "allow_outbound_ssh_from_ephemeral_agen
   source_port_range           = "*"
   source_address_prefixes     = data.azurerm_subnet.ephemeral_agents.address_prefixes
   destination_port_range      = "22"
-  destination_address_prefix  = "Internet" # setting back to all internet as it crash the packer-images build 
   #Filter only for ipv4 ips
-  #destination_address_prefixes = [
-  #  for ip in split(" ", local.github_destination_address_prefixes) : ip
-  #  if can(cidrnetmask(ip))
-  #]
+  destination_address_prefixes = [
+    for ip in split(" ", local.github_destination_address_prefixes) : ip
+    if can(cidrnetmask(ip))
+  ]
   resource_group_name         = var.controller_rg_name
   network_security_group_name = azurerm_network_security_group.ephemeral_agents.name
 }


### PR DESCRIPTION
Reverts jenkins-infra/shared-tools#163

We only need to allow outbound SSH from infra.ci.jio agents, while keeping other restrictions on other controllers.