### PR TITLE
fix(adoptium-install-jdk): don't try to move JDK folder if already at the correct place

### DIFF
--- a/adoptium/adoptium-get-jdk-link.sh
+++ b/adoptium/adoptium-get-jdk-link.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+### IMPORTANT: this script is synchronized with https://github.com/jenkins-infra/shared-tools/, please modify its content in that repository only.
+
 # Check if at least one argument was passed to the script
 # If one argument was passed and JAVA_VERSION is set, assign the argument to OS
 # If two arguments were passed, assign them to JAVA_VERSION and OS respectively

--- a/adoptium/adoptium-install-jdk.sh
+++ b/adoptium/adoptium-install-jdk.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -x
 
+### IMPORTANT: this script is synchronized with https://github.com/jenkins-infra/shared-tools/, please modify its content in that repository only.
+
 # Check if curl and tar are installed
 if ! command -v curl >/dev/null 2>&1 || ! command -v tar >/dev/null 2>&1 ; then
     echo "curl and tar are required but not installed. Exiting with status 1." >&2
@@ -43,9 +45,11 @@ fi
 EXTRACTED_DIR=$(tar -tzf /tmp/jdk.tar.gz | head -n 1 | cut -f1 -d"/")
 
 # Rename the extracted directory to /opt/jdk-${JAVA_VERSION}
-if ! mv "/opt/${EXTRACTED_DIR}" "/opt/jdk-${JAVA_VERSION}"; then
-    echo "Error: Failed to rename the extracted directory. Exiting with status 1." >&2
-    exit 1
+if [ "${EXTRACTED_DIR}" != "jdk-${JAVA_VERSION}" ]; then
+    if ! mv "/opt/${EXTRACTED_DIR}" "/opt/jdk-${JAVA_VERSION}"; then
+        echo "Error: Failed to rename the extracted directory. Exiting with status 1." >&2
+        exit 1
+    fi
 fi
 
 # Remove the downloaded archive


### PR DESCRIPTION
Report of https://github.com/jenkinsci/docker-agent/pull/1062 in the source of truth repository.

This PR also adds a mention on top of adoptium scripts to tell where they should be modified.

Closes https://github.com/jenkinsci/docker-agent/pull/1063

Refs:
- https://github.com/jenkinsci/docker-agent/pull/1063#issuecomment-3360966190
- https://github.com/jenkinsci/docker-agent/pull/1062