### PR TITLE
feat(terraform): `tee` the plan to see it in logs

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -27,7 +27,7 @@ common-tests: $(TERRAFORM_PROJECT_DIR)/.terraform/plugins/selections.json ## Exe
 	@echo "End of common-tests."
 
 plan: lint $(TERRAFORM_PROJECT_DIR)/.terraform/plugins/selections.json ## Write the planned changes into $(PLAN_FILE_NAME) (but do NOT apply them)
-	@cd $(TERRAFORM_PROJECT_DIR) && terraform plan -compact-warnings -lock=false -no-color > $(TERRAFORM_PROJECT_DIR)/$(PLAN_FILE_NAME)
+	@cd $(TERRAFORM_PROJECT_DIR) && terraform plan -compact-warnings -lock=false -no-color | tee $(TERRAFORM_PROJECT_DIR)/$(PLAN_FILE_NAME)
 	@echo "Terraform plan output can be checked under the file ./$(PLAN_FILE_NAME)"
 
 deploy: lint $(TERRAFORM_PROJECT_DIR)/.terraform/plugins/selections.json ## Deploy (apply) the terraform changes to production


### PR DESCRIPTION
This change uses `tee` to allow seing `terraform plan` logs in terraform build logs. Could be useful in case there is something not working, see footnote of https://github.com/jenkins-infra/azure/pull/1375