### PR TITLE
fix(terraform/cloudinit) add `rsync` and `screen` packages to all machines as it's usually required before Puppet or Ansible provisioning

### DIFF
--- a/terraform/cloudinit.tftpl
+++ b/terraform/cloudinit.tftpl
@@ -21,13 +21,15 @@ write_files:
       deb [trusted=yes] http://apt.puppetlabs.com focal puppet6
 # runcmd is executed after the 'write_file' module
 runcmd:
+%{ if coalesce(admin_username, "root") != "root" }
   # Map jenkins User UID to container's jenkins UID
   # As ubuntu maps to 1000 on 22.04
-  - [ groupmod, -g, "998", ${coalesce(admin_username, "jenkins-infra-team")} ]
-  - [ usermod, -u, "998", ${coalesce(admin_username, "jenkins-infra-team")} ]
+  - [ groupmod, -g, "998", ${coalesce(admin_username, "root")} ]
+  - [ usermod, -u, "998", ${coalesce(admin_username, "root")} ]
+%{ endif }
   - [ mkdir, -p, /run/puppetinstall ]
   - [ apt-get, update, --yes, --quiet ]
-  - [ apt-get, install, --yes, --quiet, --no-install-recommends, bash-completion, curl, cron, htop, iotop, locales, vim, wget ]
+  - [ apt-get, install, --yes, --quiet, --no-install-recommends, bash-completion, curl, cron, htop, iotop, locales, rsync, screen, vim, wget ]
   - [ locale-gen, en_US.UTF-8 ]
   - [ apt-get, update, --yes, --quiet ]
   - [ apt-get, install, "puppet-agent=6.*", --yes, --quiet, --no-install-recommends ]


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5084#issuecomment-4344122327

Blocked by the following 4 PRs (to avoid destroying VMs accidentally as their user_data is changed):

- Azure (trusted.ci, cert.ci, agent-2.trusted.ci) - https://github.com/jenkins-infra/azure/pull/1444
- Azure-net (private.vpn) - https://github.com/jenkins-infra/azure-net/pull/526
- DigitalOcean (census, usage and archives) - https://github.com/jenkins-infra/digitalocean/pull/288
- Aws sponsored (ci.jenkins.io) - https://github.com/jenkins-infra/terraform-aws-sponsorship/pull/490